### PR TITLE
fix(archive): nav record id shoud be encoded

### DIFF
--- a/packages/archive/src/config/resolveRecords.ts
+++ b/packages/archive/src/config/resolveRecords.ts
@@ -42,15 +42,14 @@ export function resolveRecords(navRecords: NavRecord[], pageLoaders: Loader[], d
           '/' +
             [...parents]
               .reverse()
-              .map(p => p.id)
+              .map(p => encodeURIComponent(p.id))
               .join('/') +
             '/' +
-            record.id,
+            encodeURIComponent(record.id),
         )
 
         resolvedRecord = {
           ...basicRecord,
-          id: record.id,
           type: 'item',
           path,
           pageData: resolvedPageData,


### PR DESCRIPTION
nav 路径需要经过转义，否则浏览器的路径与 record 的路径无法对应，不能实现 url跳转