### PR TITLE
fix: cjs didn't work, now `type: module` isn't necessary anymore

### DIFF
--- a/examples/vue2-simple/archive.config.js
+++ b/examples/vue2-simple/archive.config.js
@@ -1,12 +1,8 @@
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'node:url'
+const { resolve } = require('path')
+const { defineConfig } = require('@idux/archive')
+const { createArchiveVue2PageLoader, createArchiveVue2DemoLoader } = require('@idux/archive-loader-vue2')
 
-import { defineConfig } from '@idux/archive'
-import { createArchiveVue2PageLoader, createArchiveVue2DemoLoader } from '@idux/archive-loader-vue2'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-export default defineConfig({
+module.exports = defineConfig({
   root: resolve(__dirname, './demos'),
   theme: {
     themeStyle: 'seer',

--- a/examples/vue2-simple/package.json
+++ b/examples/vue2-simple/package.json
@@ -2,10 +2,9 @@
   "name": "idux-archive-example-vue2-simple",
   "private": true,
   "version": "0.3.1",
-  "type": "module",
   "scripts": {
-    "idux-archive:dev": "node ./patch.js && idux-archive dev",
-    "idux-archive:build": "node ./patch.js && idux-archive build"
+    "archive:dev": "node ./patch.js && archive dev",
+    "archive:build": "node ./patch.js && archive build"
   },
   "dependencies": {
     "@idux/archive-app": "^0.3.1",

--- a/examples/vue2-simple/patch.js
+++ b/examples/vue2-simple/patch.js
@@ -1,10 +1,8 @@
 
-import { createRequire } from 'node:module'
-import { readFileSync, writeFileSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
+const { readFileSync, writeFileSync } = require('node:fs')
+const { resolve, dirname } = require('node:path')
 
-const _require = createRequire(import.meta.url)
-const vueTemplateIndexPath = resolve(dirname(_require.resolve('vue-template-compiler')), 'index.js')
+const vueTemplateIndexPath = resolve(dirname(require.resolve('vue-template-compiler')), 'index.js')
 
 
 writeFileSync(vueTemplateIndexPath, readFileSync(vueTemplateIndexPath, 'utf-8').replace('vueVersion && vueVersion !== packageVersion', 'false'))

--- a/examples/vue3-simple/archive.config.js
+++ b/examples/vue3-simple/archive.config.js
@@ -1,12 +1,8 @@
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'node:url'
+const { resolve } = require('path')
+const { defineConfig } = require('@idux/archive')
+const { createArchiveVuePageLoader, createArchiveVueDemoLoader } = require('@idux/archive-loader-vue')
 
-import { defineConfig } from '@idux/archive'
-import { createArchiveVuePageLoader, createArchiveVueDemoLoader } from '@idux/archive-loader-vue'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-export default defineConfig({
+module.exports = defineConfig({
   root: resolve(__dirname, './demos'),
   theme: {
     themeStyle: 'seer',

--- a/examples/vue3-simple/package.json
+++ b/examples/vue3-simple/package.json
@@ -2,10 +2,9 @@
   "name": "idux-archive-example-vue3-simple",
   "private": true,
   "version": "0.3.1",
-  "type": "module",
   "scripts": {
-    "idux-archive:dev": "idux-archive dev",
-    "idux-archive:build": "idux-archive build"
+    "archive:dev": "archive dev",
+    "archive:build": "archive build"
   },
   "dependencies": {
     "@idux/archive-app": "^0.3.1",

--- a/packages/archive-loader-vue/package.json
+++ b/packages/archive-loader-vue/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/archive-loader-vue2/package.json
+++ b/packages/archive-loader-vue2/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/archive-loader-vue2/src/teleport.ts
+++ b/packages/archive-loader-vue2/src/teleport.ts
@@ -5,6 +5,8 @@
  * found in the LICENSE file at https://github.com/IDuxFE/archive/blob/main/LICENSE
  */
 
+/* eslint-disable vue/no-deprecated-destroyed-lifecycle */
+
 import Vue, { type Component } from 'vue'
 
 const props = {
@@ -35,7 +37,7 @@ export default Vue.extend({
       subtree: true,
     })
   },
-  beforeUnmount() {
+  beforeDestroy() {
     this.removeComponent()
   },
   methods: {

--- a/packages/archive/package.json
+++ b/packages/archive/package.json
@@ -2,12 +2,18 @@
   "name": "@idux/archive",
   "version": "0.3.1",
   "description": "",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
   "types": "./types/index.d.ts",
   "type": "module",
   "bin": {
-    "idux-archive": "./dist/bin.mjs"
+    "archive": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": [
     "dist"

--- a/packages/archive/scripts/buildScripts.js
+++ b/packages/archive/scripts/buildScripts.js
@@ -24,7 +24,7 @@ const getConfig = buildOption => ({
     lib: {
       entry: buildOption.input,
       formats: ['es', 'cjs'],
-      fileName: format => (format === 'cjs' ? `${buildOption.filename}.cjs` : `${buildOption.filename}.mjs`),
+      fileName: format => (format === 'cjs' ? `${buildOption.filename}.cjs` : `${buildOption.filename}.js`),
     },
 
     rollupOptions: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
文档项目必须指定 type="module"，否则无法使用


## What is the new behavior?
修复以上问题，并将全部demo改成 cjs 写法

## Other information
修改 idux-archive 命令为 archive