### PR TITLE
fix(app): components shouldn't export vue3 related component

### DIFF
--- a/packages/archive-app/vendor/components.ts
+++ b/packages/archive-app/vendor/components.ts
@@ -5,12 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/archive/blob/main/LICENSE
  */
 
-import Demo from '../src/components/demo'
-
 export * from '@idux/components/tooltip'
 export * from '@idux/components/button'
 export * from '@idux/components/icon'
 export { createDemoInstance } from '../createDemoInstance'
-
-export const DemoComp = Demo
-export type { DemoProps } from '../src/components/demo/Demo'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
app 导出的内部组件包含了依赖外部 vue的 demo 组件，导致 vue2项目引用时报错


## What is the new behavior?
去掉导出的demo组件，仅提供createDemoInstance方法使用demo组件

## Other information
