### PR TITLE
docs: remoe unexported DemoComp

### DIFF
--- a/examples/vue2-simple/vite.config.ts
+++ b/examples/vue2-simple/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   plugins: [
     createVuePlugin({
       include: [/\.vue$/, /\.md$/],
+      vueTemplateOptions: {
+        compilerOptions: {
+          whitespace: 'preserve'
+        }
+      }
     }),
   ],
   build: {

--- a/examples/vue3-simple/demos/Page.page.md
+++ b/examples/vue3-simple/demos/Page.page.md
@@ -1,9 +1,3 @@
-<script setup lang="ts">
-import item from 'archive-demo:./demoPage1/HelloWorld.demo.vue';
-import { DemoComp } from '@idux/archive-app/components'
-
-</script>
-
 # CustomPage
 
 *.page.{md,vue} file can be parsed as an individual page
@@ -58,6 +52,3 @@ write markdown table
 | th1 | th2 | th3  |
 | --- | --- | --- |
 | td1 | td2 | td3 |
-
-
-<DemoComp :demo-item="item"></DemoComp>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. demo 中包含没有导出的 DemoComp
2. vue2下 vue SFC编译会去掉多余的换行和空格，导致markdown 中的代码展示不正常
## What is the new behavior?
修复以上问题

## Other information
