### PR TITLE
fix(loader-vue,loader-vue2): sourceCode lang should be infered

### DIFF
--- a/packages/archive-loader-vue/src/genSourceCodes.ts
+++ b/packages/archive-loader-vue/src/genSourceCodes.ts
@@ -16,6 +16,12 @@ export function genSourceCode(filename: string, code: string, md: MarkdownRender
   return {
     filename: filename,
     code: _code,
-    parsedCode: md.render('```html \r\n' + _code + '\r\n ```'),
+    parsedCode: md.render('```' + inferCodeType(filename) + ' \r\n' + _code + '\r\n ```'),
   }
+}
+
+function inferCodeType(filename: string): string {
+  const extension = filename.split('.').pop()
+
+  return extension ?? 'js'
 }

--- a/packages/archive-loader-vue2/src/genSourceCodes.ts
+++ b/packages/archive-loader-vue2/src/genSourceCodes.ts
@@ -16,6 +16,12 @@ export function genSourceCode(filename: string, code: string, md: MarkdownRender
   return {
     filename: filename,
     code: _code,
-    parsedCode: md.render('```html \r\n' + _code + '\r\n ```'),
+    parsedCode: md.render('```' + inferCodeType(filename) + ' \r\n' + _code + '\r\n ```'),
   }
+}
+
+function inferCodeType(filename: string): string {
+  const extension = filename.split('.').pop()
+
+  return extension ?? 'js'
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
除了vue文件，其他文件类型的源码展示，lang不正确，导致高亮不正确

## What is the new behavior?
根据文件名推测源码lang

## Other information
